### PR TITLE
wintime: os.exit(1) when no arguments

### DIFF
--- a/wintime/main.go
+++ b/wintime/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	if len(os.Args) == 1 {
 		fmt.Println("No argument was provided")
-		os.Exit(0)
+		os.Exit(1)
 	}
 	var cmd *exec.Cmd
 	_, err := exec.LookPath(os.Args[1])


### PR DESCRIPTION
Exit code 0 signals that a program completed its function successfully. But we get an error message instead of measured time when there're no arguments. If I would use it in a shell script and try to parse output based on exit code, I'll fail.